### PR TITLE
refactor: simplify save_market serialization

### DIFF
--- a/src/storage.py
+++ b/src/storage.py
@@ -220,7 +220,7 @@ def _market_path(uid: int) -> str:
     return os.path.join(MARKET_DIR, f"{uid}.json")
 
 def save_market(m: Market):
-    _write_json(_market_path(m.user_id), json.loads(m.model_dump_json()))
+    _write_json(_market_path(m.user_id), m.model_dump(mode="json"))
 
 def load_market(uid: int) -> Optional[Market]:
     raw = _read_json(_market_path(uid))


### PR DESCRIPTION
## Summary
- avoid unnecessary JSON serialization by passing dict to `_write_json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c80cc1f7408322b0e0652889e89fae