### PR TITLE
feat: allow forced market levels

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
@@ -318,9 +319,9 @@ class Core(commands.Cog):
         view = Paginator(pages, interaction.user.id, timeout=120, files=files)
         await view.send(interaction)
 
-    @app_commands.command(name="market", description="Show the service market (auto-refreshes every 5 minutes)")
     @app_commands.describe(level="Force market level (0..max)")
-    async def market(self, interaction: discord.Interaction, level: int | None = None):
+    @app_commands.command(name="market", description="Show the service market (auto-refreshes every 5 minutes)")
+    async def market(self, interaction: discord.Interaction, level: Optional[int] = None):
         uid = interaction.user.id
         pl = load_player(uid)
         if not pl:

--- a/src/models.py
+++ b/src/models.py
@@ -217,6 +217,8 @@ class Market(BaseModel):
     user_id: int
     jobs: List[Job] = Field(default_factory=list)
     ts: int = Field(default_factory=now_ts)
+    level: int = 0
+    forced_level: int | None = None
 
 class Player(BaseModel):
     reputation: int = 0

--- a/src/storage.py
+++ b/src/storage.py
@@ -227,11 +227,17 @@ def load_market(uid: int) -> Optional[Market]:
     return Market(**raw) if raw else None
 
 def generate_market(uid: int, jobs_count: int = 5, forced_level: int | None = None) -> Market:
+    """Generate market jobs.
+
+    If ``forced_level`` is provided, it overrides the reputation-based level
+    and is persisted with the market.
     """
-    Generate market based on player's reputation → market level.
-    """
-    pl = load_player(uid)  # fixed: no self-import
-    lvl = forced_level if forced_level is not None else market_level_from_rep(pl.reputation if pl else 0)
+    pl = load_player(uid)
+    lvl = (
+        max(0, forced_level)
+        if forced_level is not None
+        else market_level_from_rep(pl.reputation if pl else 0)
+    )
 
     jobs: List[Job] = []
     for i in range(jobs_count):


### PR DESCRIPTION
## Summary
- track current and forced market levels in Market model
- allow generating markets at a specified level
- add `/market [level]` command that refreshes and displays forced levels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c81da2e4788322b977b3f952fbf9b2