### PR TITLE
Add support for new sub-skill categories

### DIFF
--- a/src/assets_util.py
+++ b/src/assets_util.py
@@ -43,7 +43,8 @@ def action_image_path(girl_name: str, base_id: str, main_skill: str, sub_skill: 
       assets/girls/<name>/<main>/<sub>.png
       fallback: assets/girls/<base_id>/<main>/<sub>.png
 
-    where <main> ∈ human|insect|beast|monster, <sub> ∈ anal|vaginal|oral|breast
+    where <main> ∈ human|insect|beast|monster,
+          <sub> ∈ anal|vaginal|oral|breast|hand|foot|toy
     """
     name_slug = _slug(girl_name)
     base_slug = _slug(base_id) if base_id else None

--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -9,7 +9,8 @@ from ..storage import (
     resolve_job, dismantle_girl
 )
 from ..models import (
-    RARITY_COLORS, make_bar, skill_xp_threshold, get_level, get_xp, market_level_from_rep
+    RARITY_COLORS, make_bar, skill_xp_threshold, get_level, get_xp, market_level_from_rep,
+    MAIN_SKILLS, SUB_SKILLS,
 )
 from ..assets_util import profile_image_path, action_image_path, pregnant_profile_image_path
 
@@ -303,12 +304,12 @@ class Core(commands.Cog):
 
             em.add_field(
                 name="Skills",
-                value=fmt_skill_lines(g.skills, ['Human', 'Insect', 'Beast', 'Monster'], g.prefs_skills),
+                value=fmt_skill_lines(g.skills, MAIN_SKILLS, g.prefs_skills),
                 inline=False
             )
             em.add_field(
                 name="Sub",
-                value=fmt_skill_lines(g.subskills, ['VAGINAL', 'ANAL', 'ORAL', 'BREAST'], g.prefs_subskills),
+                value=fmt_skill_lines(g.subskills, SUB_SKILLS, g.prefs_subskills),
                 inline=False
             )
 

--- a/src/models.py
+++ b/src/models.py
@@ -8,7 +8,7 @@ import time
 # -----------------------------------------------------------------------------
 
 MAIN_SKILLS = ["Human", "Insect", "Beast", "Monster"]
-SUB_SKILLS  = ["VAGINAL", "ANAL", "ORAL", "BREAST"]  # NIPPLE -> BREAST
+SUB_SKILLS  = ["VAGINAL", "ANAL", "ORAL", "BREAST", "HAND", "FOOT", "TOY"]  # NIPPLE -> BREAST
 
 RARITY_WEIGHTS = {"R": 70, "SR": 20, "SSR": 9, "UR": 1}
 RARITY_COLORS  = {"R": 0x9fa6b2, "SR": 0x60a5fa, "SSR": 0xf59e0b, "UR": 0x8b5cf6}

--- a/src/storage.py
+++ b/src/storage.py
@@ -71,11 +71,16 @@ def load_player(uid: int) -> Optional[Player]:
     # --- migration of legacy skills structure (ints -> {'level','xp'}) ---
     girls = raw.get("girls", [])
     for g in girls:
-        # normalize skills only if any value is int (legacy)
-        if g.get("skills") and any(isinstance(v, int) for v in g["skills"].values()):
-            g["skills"] = normalize_skill_map(g.get("skills", {}))
-        if g.get("subskills") and any(isinstance(v, int) for v in g["subskills"].values()):
-            g["subskills"] = normalize_skill_map(g.get("subskills", {}))
+        # normalize skills/subskills (always) to ensure new entries exist
+        skills_raw = g.get("skills") or {}
+        if not isinstance(skills_raw, dict):
+            skills_raw = {}
+        g["skills"] = normalize_skill_map(skills_raw)
+
+        subskills_raw = g.get("subskills") or {}
+        if not isinstance(subskills_raw, dict):
+            subskills_raw = {}
+        g["subskills"] = normalize_skill_map(subskills_raw)
 
         # normalize preferences maps if present
         g["prefs_skills"]    = normalize_prefs(g.get("prefs_skills", {}), MAIN_SKILLS)


### PR DESCRIPTION
## Summary
- add the HAND, FOOT, and TOY sub-skills and expose them through girl defaults
- normalize stored player data to always include the extended sub-skill set
- refresh UI skill lists and asset lookup docs to cover the new categories

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c87b73d2688322b720e7d5720080e6