### PR TITLE
Normalize market job option values

### DIFF
--- a/src/game/services.py
+++ b/src/game/services.py
@@ -193,16 +193,21 @@ class GameService:
             if not isinstance(job, dict):
                 continue
             original_id = job.get("job_id")
-            base = f"J{idx}" if not original_id or original_id == "none" else str(original_id)
+            original_text = str(original_id) if original_id is not None else ""
+            job_id = original_text.strip()
+            base = job_id if job_id and job_id.lower() != "none" else f"J{idx}"
+            base = base.strip() or f"J{idx}"
             candidate = base
             suffix = 2
-            while candidate in seen or candidate == "none":
+            normalized = candidate.strip().casefold()
+            while not normalized or normalized == "none" or normalized in seen:
                 candidate = f"{base}-{suffix}"
                 suffix += 1
-            if candidate != original_id:
+                normalized = candidate.strip().casefold()
+            if candidate != job_id or original_text != job_id:
                 job["job_id"] = candidate
                 changed = True
-            seen.add(candidate)
+            seen.add(normalized)
         if changed:
             raw_market["jobs"] = jobs
         return changed

--- a/src/game/views.py
+++ b/src/game/views.py
@@ -260,19 +260,26 @@ class MarketWorkView(discord.ui.View):
         if not market or not market.jobs:
             return options
 
-        seen_ids: set[str] = {"none"}
+        seen_normalized: set[str] = {"none"}
         sanitized = False
 
         for idx, job in enumerate(market.jobs[:24], start=1):
             raw_id = getattr(job, "job_id", None)
             job_id = str(raw_id).strip() if raw_id is not None else ""
             base_id = job_id if job_id and job_id.lower() != "none" else f"J{idx}"
+            base_id = base_id.strip() or f"J{idx}"
 
             candidate = base_id
             suffix = 2
-            while candidate.lower() == "none" or candidate in seen_ids:
+            normalized = candidate.strip().casefold()
+            while (
+                not normalized
+                or normalized == "none"
+                or normalized in seen_normalized
+            ):
                 candidate = f"{base_id}-{suffix}"
                 suffix += 1
+                normalized = candidate.strip().casefold()
 
             if candidate != job_id:
                 try:
@@ -283,7 +290,7 @@ class MarketWorkView(discord.ui.View):
                 if self.selected_job_id == job_id:
                     self.selected_job_id = candidate
 
-            seen_ids.add(candidate)
+            seen_normalized.add(normalized)
 
             sub_part = f" + {job.demand_sub} L{job.demand_sub_level}" if job.demand_sub else ""
             label = f"{candidate} • {job.demand_main} L{job.demand_level}{sub_part}"


### PR DESCRIPTION
## Summary
- normalize market job identifiers before building Discord select options to guarantee unique values
- harden market deserialization by deduplicating stored job IDs case-insensitively and trimming whitespace

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c98d6e4bb08322b052369b340385f4