### PR TITLE
Add change report helper for admin sync command

### DIFF
--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -1,43 +1,113 @@
+from __future__ import annotations
+
 import discord, json, os
+from typing import Any, Dict, Optional
 from discord import app_commands
 from discord.ext import commands
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 CONFIG_PATH = os.path.join(os.path.dirname(BASE_DIR), "config.json")
 
-def load_cfg():
+def load_cfg() -> Dict[str, Any]:
     with open(CONFIG_PATH, "r", encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+    if isinstance(data, dict):
+        return data
+    return {}
 
 class Admin(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    async def _sync_commands(self, *, report_changes: bool = False) -> Optional[Dict[str, Any]]:
+        cfg = load_cfg()
+        raw_guild_id: Any = None
+        if isinstance(cfg, dict):
+            raw_guild_id = cfg.get("guild_id")
+            if raw_guild_id is None:
+                discord_section = cfg.get("discord")
+                if isinstance(discord_section, dict):
+                    raw_guild_id = discord_section.get("guild_id")
+
+        guild_id: Optional[int] = None
+        invalid_guild_value: Any = None
+        if isinstance(raw_guild_id, int):
+            guild_id = raw_guild_id if raw_guild_id > 0 else None
+        elif isinstance(raw_guild_id, str):
+            trimmed = raw_guild_id.strip()
+            if trimmed:
+                try:
+                    guild_id = int(trimmed)
+                except ValueError:
+                    invalid_guild_value = raw_guild_id
+            else:
+                guild_id = None
+        elif raw_guild_id not in (None, "", 0):
+            invalid_guild_value = raw_guild_id
+
+        result: Dict[str, Any] = {
+            "scope": "guild" if guild_id else "global",
+            "guild_id": guild_id,
+            "synced_count": 0,
+            "commands": [],
+            "fallback_reason": None,
+        }
+
+        if guild_id:
+            guild_obj = discord.Object(id=guild_id)
+            self.bot.tree.copy_global_to(guild=guild_obj)
+            synced = await self.bot.tree.sync(guild=guild_obj)
+            result["commands"] = [cmd.name for cmd in synced]
+            result["synced_count"] = len(synced)
+        else:
+            if invalid_guild_value is not None:
+                result["fallback_reason"] = "invalid_guild_id"
+                result["invalid_value"] = invalid_guild_value
+            synced = await self.bot.tree.sync()
+            result["commands"] = [cmd.name for cmd in synced]
+            result["synced_count"] = len(synced)
+
+        if report_changes:
+            return result
+        return None
+
     @app_commands.command(name="sync", description="Resync slash commands (owner only)")
-    async def sync(self, interaction: discord.Interaction):
+    async def sync(self, interaction: discord.Interaction) -> None:
         app = self.bot.application
         if app is None or app.owner is None or interaction.user.id != app.owner.id:
-            return await interaction.response.send_message("Only the bot application owner can do this.", ephemeral=True)
-        cfg = load_cfg()
-        guild_id = int(cfg.get("guild_id", 0))
-        if guild_id:
-            g = discord.Object(id=guild_id)
-            self.bot.tree.copy_global_to(guild=g)
-            synced = await self.bot.tree.sync(guild=g)
-            await interaction.response.send_message(f"Synced {len(synced)} commands for guild {guild_id}.", ephemeral=True)
-        else:
-            synced = await self.bot.tree.sync()
             await interaction.response.send_message(
-                f"Globally synced {len(synced)} commands.", ephemeral=True
+                "Only the bot application owner can do this.", ephemeral=True
             )
+            return
+
+        report = await self._sync_commands(report_changes=True)
+        message: str
+        if report is None:
+            message = "No commands were synchronized."
+        else:
+            scope = report.get("scope")
+            count = report.get("synced_count", 0)
+            fallback = report.get("fallback_reason")
+            if scope == "guild" and report.get("guild_id"):
+                message = f"Synced {count} commands for guild {report['guild_id']}."
+            else:
+                message = f"Globally synced {count} commands."
+                if fallback == "invalid_guild_id":
+                    invalid_value = report.get("invalid_value")
+                    message = (
+                        f"Invalid guild id {invalid_value!r}; globally synced {count} commands instead."
+                    )
+
+        await interaction.response.send_message(message, ephemeral=True)
 
     @app_commands.command(name="invite", description="Get bot invite link (applications.commands + bot)")
-    async def invite(self, interaction: discord.Interaction):
+    async def invite(self, interaction: discord.Interaction) -> None:
         user = self.bot.user
         if not user:
-            return await interaction.response.send_message("The bot is not initialized yet.", ephemeral=True)
+            await interaction.response.send_message("The bot is not initialized yet.", ephemeral=True)
+            return
         url = f"https://discord.com/api/oauth2/authorize?client_id={user.id}&permissions=0&scope=bot%20applications.commands"
         await interaction.response.send_message(f"Invite: {url}", ephemeral=True)
 
-async def setup(bot: commands.Bot):
+async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Admin(bot))


### PR DESCRIPTION
## Summary
- add a helper that synchronizes commands and optionally returns a change report
- annotate admin slash commands as returning None and simplify early exits

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c997e6052c8322b8abb51a4fea5479