### PR TITLE
Sync renown decay and fix pregnancy progress helpers

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -168,6 +168,7 @@ class Core(commands.Cog):
         # Normalize / regen before render
         brothel = pl.ensure_brothel()
         brothel.apply_decay()
+        pl.renown = brothel.renown
         for g in pl.girls:
             g.normalize_skill_structs()
             g.apply_regen(brothel)
@@ -227,6 +228,7 @@ class Core(commands.Cog):
 
         brothel = pl.ensure_brothel()
         brothel.apply_decay()
+        pl.renown = brothel.renown
 
         action_val = (choice_value(action, default="view") or "view").lower()
         if action_val not in {"view", "upgrade", "maintain", "promote"}:
@@ -411,6 +413,7 @@ class Core(commands.Cog):
 
         brothel = pl.ensure_brothel()
         brothel.apply_decay()
+        pl.renown = brothel.renown
         for g in pl.girls:
             g.normalize_skill_structs()
             g.apply_regen(brothel)
@@ -681,6 +684,7 @@ class Core(commands.Cog):
 
         brothel = pl.ensure_brothel()
         brothel.apply_decay()
+        pl.renown = brothel.renown
         for g in pl.girls:
             g.normalize_skill_structs()
             g.apply_regen(brothel)

--- a/src/game/services.py
+++ b/src/game/services.py
@@ -466,6 +466,7 @@ class GameService:
         brothel = player.ensure_brothel()
         girl.apply_regen(brothel)
         brothel.apply_decay()
+        player.renown = brothel.renown
 
         if girl.pregnant:
             return {"ok": False, "reason": "Girl is pregnant", "reward": 0}

--- a/src/game/views.py
+++ b/src/game/views.py
@@ -331,6 +331,7 @@ class MarketWorkView(discord.ui.View):
             return None
         brothel = pl.ensure_brothel()
         brothel.apply_decay()
+        pl.renown = brothel.renown
         for g in pl.girls:
             g.normalize_skill_structs()
             g.apply_regen(brothel)

--- a/src/models.py
+++ b/src/models.py
@@ -268,6 +268,14 @@ class Girl(BaseModel):
         elapsed = max(0, now_ts() - self.pregnant_since_ts)
         return int(min(PREGNANCY_TOTAL_POINTS, elapsed // PREGNANCY_TICK_SECONDS))
 
+    def pregnancy_progress_points(self) -> int:
+        """Alias for pregnancy progress used by presentation helpers."""
+        return self.pregnancy_points()
+
+    def pregnancy_total_points(self) -> int:
+        """Total number of points required to complete a pregnancy."""
+        return PREGNANCY_TOTAL_POINTS
+
     def normalize_skill_structs(self):
         """Normalize legacy data structures for skills/subskills and preferences."""
         self.skills    = normalize_skill_map(self.skills)


### PR DESCRIPTION
## Summary
- propagate decayed brothel renown back to the player wherever decay runs so persistence reflects the reduced value
- add pregnancy progress helper aliases on `Girl` so embeds render pregnant girls without crashing

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c99c1b2d108322935569da64626bea