### PR TITLE
Delay gacha cost deduction until after successful roll

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -344,16 +344,19 @@ class Core(commands.Cog):
             await interaction.response.send_message("Not enough coins.", ephemeral=True)
             return
 
-        pl.currency -= cost
-        save_player(pl)
-
         try:
             girls = roll_gacha(interaction.user.id, times)
         except RuntimeError as exc:
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
-        # re-load to display current state if needed
-        pl = load_player(interaction.user.id)
+        # Re-load to capture any updates from roll_gacha (such as new girls)
+        updated_pl = load_player(interaction.user.id)
+        if not updated_pl:
+            updated_pl = pl
+            updated_pl.girls.extend(girls)
+        updated_pl.currency -= cost
+        save_player(updated_pl)
+        pl = updated_pl
 
         embeds = []
         for g in girls:

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch
+
+from src.cogs.core import Core
+from src.models import Player
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, *args, **kwargs):
+        self.messages.append((args, kwargs))
+
+
+class DummyUser:
+    def __init__(self, uid: int, display_name: str = "Tester"):
+        self.id = uid
+        self.display_name = display_name
+
+
+class DummyInteraction:
+    def __init__(self, uid: int):
+        self.user = DummyUser(uid)
+        self.response = DummyResponse()
+
+
+class GachaCommandTests(unittest.IsolatedAsyncioTestCase):
+    async def test_failed_gacha_roll_keeps_balance(self):
+        core = Core.__new__(Core)
+        uid = 123
+        interaction = DummyInteraction(uid)
+
+        player = Player(user_id=uid, currency=500, girls=[])
+        player.ensure_brothel()
+
+        with patch("src.cogs.core.load_player", return_value=player) as mock_load, \
+                patch("src.cogs.core.save_player") as mock_save, \
+                patch("src.cogs.core.roll_gacha", side_effect=RuntimeError("Catalog empty")):
+            await Core.gacha.callback(core, interaction, times=1)
+
+        self.assertEqual(player.currency, 500)
+        mock_save.assert_not_called()
+        mock_load.assert_called_once()
+        self.assertTrue(interaction.response.messages)
+        message_args, message_kwargs = interaction.response.messages[0]
+        self.assertEqual(message_args, ("Catalog empty",))
+        self.assertTrue(message_kwargs.get("ephemeral"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- delay the `/gacha` coin deduction until after `roll_gacha` succeeds, preserving girls when reloading fails
- add a regression test covering a gacha failure to ensure player balances remain unchanged

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68c9a7b008348322a653b7f79ca65be9