### PR TITLE
Fix gacha roll coin handling

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -328,32 +328,11 @@ class Core(commands.Cog):
         if not pl:
             await interaction.response.send_message("Use /start first.", ephemeral=True)
             return
-        brothel = pl.ensure_brothel()
-        slots_left = brothel.rooms - len(pl.girls)
-        if slots_left <= 0:
-            await interaction.response.send_message("All rooms are occupied. Expand your brothel first.", ephemeral=True)
-            return
-        if times > slots_left:
-            await interaction.response.send_message(
-                f"Only {slots_left} room(s) available. Reduce rolls or expand rooms.",
-                ephemeral=True,
-            )
-            return
-        cost = 100 * times
-        if pl.currency < cost:
-            await interaction.response.send_message("Not enough coins.", ephemeral=True)
-            return
-
-        pl.currency -= cost
-        save_player(pl)
-
         try:
-            girls = roll_gacha(interaction.user.id, times)
+            girls, total_cost = roll_gacha(interaction.user.id, times)
         except RuntimeError as exc:
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
-        # re-load to display current state if needed
-        pl = load_player(interaction.user.id)
 
         embeds = []
         for g in girls:
@@ -369,7 +348,7 @@ class Core(commands.Cog):
             embeds.append(em)
 
         await interaction.response.send_message(
-            content=f"Spent {EMOJI_COIN} **{cost}**. You got **{len(girls)}** roll(s).",
+            content=f"Spent {EMOJI_COIN} **{total_cost}**. You got **{len(girls)}** roll(s).",
             embeds=embeds[:10],
         )
 

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -1,0 +1,77 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.game.repository import DataStore
+from src.game.services import GameService
+
+
+class GachaRollTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmpdir.name)
+        self.roll_cost = 100
+
+        config_data = {
+            "gacha": {
+                "roll_cost": self.roll_cost,
+                "starter_coins": 500,
+                "starter_girl_id": "g001",
+            }
+        }
+        (self.base / "config.json").write_text(json.dumps(config_data))
+
+        data_dir = self.base / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        catalog_data = {
+            "girls": [
+                {
+                    "id": "g001",
+                    "name": "Test Girl",
+                    "rarity": "R",
+                    "base": {
+                        "level": 1,
+                        "skills": {},
+                        "subskills": {},
+                    },
+                }
+            ]
+        }
+        (data_dir / "girls_catalog.json").write_text(json.dumps(catalog_data))
+
+        store = DataStore(self.base)
+        self.service = GameService(store)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_double_roll_with_one_room_does_not_consume_extra_coins(self):
+        uid = 123
+        # Starter pack gives one girl and ample currency.
+        self.service.grant_starter_pack(uid)
+        # Spend one roll to leave exactly one free room before the scenario.
+        self.service.roll_gacha(uid, times=1)
+
+        snapshot = self.service.load_player(uid)
+        self.assertIsNotNone(snapshot)
+        brothel = snapshot.ensure_brothel()
+        self.assertEqual(brothel.rooms - len(snapshot.girls), 1)
+        coins_before = snapshot.currency
+
+        girls, total_cost = self.service.roll_gacha(uid, times=1)
+        self.assertEqual(len(girls), 1)
+        self.assertEqual(total_cost, self.roll_cost)
+
+        after_success = self.service.load_player(uid)
+        self.assertEqual(after_success.currency, coins_before - total_cost)
+
+        with self.assertRaises(RuntimeError):
+            self.service.roll_gacha(uid, times=1)
+
+        after_failure = self.service.load_player(uid)
+        self.assertEqual(after_failure.currency, after_success.currency)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move coin deductions for gacha rolls into `GameService.roll_gacha`, guard against failures, and derive the cost from config
- update the `/gacha` command to rely on the service result so coins are only spent after a successful roll
- add a regression unit test that double rolls with one room do not consume extra coins

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68c9b9bc8564832293f3f02a711f242b