### PR TITLE
Allow brothel expand action

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -67,6 +67,20 @@ from ..game.utils import choice_value
 from ..game.views import MarketWorkView, Paginator
 
 
+BROTHEL_ALLOWED_ACTIONS = {"view", "upgrade", "maintain", "promote", "expand"}
+
+
+def normalize_brothel_action(
+    action: app_commands.Choice[str] | None,
+) -> str:
+    """Normalize the incoming action choice for /brothel commands."""
+
+    action_val = (choice_value(action, default="view") or "view").lower()
+    if action_val not in BROTHEL_ALLOWED_ACTIONS:
+        return "view"
+    return action_val
+
+
 # -----------------------------------------------------------------------------
 # Core Cog
 # -----------------------------------------------------------------------------
@@ -230,9 +244,7 @@ class Core(commands.Cog):
         brothel.apply_decay()
         pl.renown = brothel.renown
 
-        action_val = (choice_value(action, default="view") or "view").lower()
-        if action_val not in {"view", "upgrade", "maintain", "promote"}:
-            action_val = "view"
+        action_val = normalize_brothel_action(action)
 
         facility_val = choice_value(facility)
         if facility_val:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,21 @@
+import unittest
+from types import SimpleNamespace
+
+from src.cogs.core import normalize_brothel_action
+
+
+class BrothelActionNormalizationTests(unittest.TestCase):
+    def test_expand_choice_is_preserved(self):
+        choice = SimpleNamespace(value="expand")
+        self.assertEqual(normalize_brothel_action(choice), "expand")
+
+    def test_invalid_choice_defaults_to_view(self):
+        choice = SimpleNamespace(value="invalid")
+        self.assertEqual(normalize_brothel_action(choice), "view")
+
+    def test_none_choice_defaults_to_view(self):
+        self.assertEqual(normalize_brothel_action(None), "view")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- include the expand rooms choice in the normalized /brothel action handling
- reuse a helper to validate action choices so the expand branch remains reachable
- cover the normalization logic with a regression unit test

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68c9c5a411e883229a0dda0b7d58c95a