### PR TITLE
Use configurable starter coins

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -151,10 +151,13 @@ class Core(commands.Cog):
 
         pl = grant_starter_pack(uid)
         girl = pl.girls[0]
+        starter_coins = pl.currency
 
         embed = discord.Embed(
             title=f"{EMOJI_SPARK} Starter Pack",
-            description=f"You received {EMOJI_COIN} **500** and your first girl!",
+            description=(
+                f"You received {EMOJI_COIN} **{starter_coins}** and your first girl!"
+            ),
             color=0x60A5FA,
         )
         embed.add_field(

--- a/src/game/services.py
+++ b/src/game/services.py
@@ -240,7 +240,18 @@ class GameService:
             index = random.choices(range(len(entries)), weights=weights, k=1)[0]
             base_entry = entries[index]
 
-        player = Player(user_id=uid, currency=500, girls=[])
+        config = self._load_config()
+        gacha_cfg = config.get("gacha") if isinstance(config, dict) else None
+        raw_starter_coins = (gacha_cfg or {}).get("starter_coins", 500)
+        try:
+            starter_coins = int(raw_starter_coins)
+        except (TypeError, ValueError):
+            starter_coins = 500
+        else:
+            if starter_coins < 0:
+                starter_coins = 0
+
+        player = Player(user_id=uid, currency=starter_coins, girls=[])
         brothel = player.ensure_brothel()
         player.renown = brothel.renown
 

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -72,6 +72,27 @@ class GachaRollTestCase(unittest.TestCase):
         after_failure = self.service.load_player(uid)
         self.assertEqual(after_failure.currency, after_success.currency)
 
+    def test_starter_coins_follow_config_value(self):
+        uid = 456
+        new_starter_coins = 987
+        config_data = {
+            "gacha": {
+                "roll_cost": self.roll_cost,
+                "starter_coins": new_starter_coins,
+                "starter_girl_id": "g001",
+            }
+        }
+        (self.base / "config.json").write_text(json.dumps(config_data))
+        # Reset cached config so the updated value is picked up.
+        self.service._config_cache = None
+
+        player = self.service.grant_starter_pack(uid)
+        self.assertEqual(player.currency, new_starter_coins)
+
+        stored = self.service.load_player(uid)
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.currency, new_starter_coins)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- load starter pack coin amount from configuration instead of a hardcoded value
- surface the awarded starter coins in the /start response embed
- add a regression test ensuring config changes affect new player balances

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c73d5ee88322a46cb9940b09ccae