### PR TITLE
Fix brothel lust gating after applying modifiers

### DIFF
--- a/src/game/services.py
+++ b/src/game/services.py
@@ -514,6 +514,7 @@ class GameService:
             reward_multiplier *= brothel.reward_modifier()
             injury_base *= brothel.injury_modifier()
             lust_cost = max(1, int(lust_cost * brothel.lust_modifier()))
+            lust_ok = girl.lust >= lust_cost
 
         success_chance = max(0.05, min(0.97, success_chance))
         reward_multiplier = max(0.45, min(2.5, reward_multiplier))

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -1,0 +1,47 @@
+import unittest
+
+from src.game.services import GameService
+from src.models import BrothelState, Girl, Job
+
+
+class EvaluateJobTests(unittest.TestCase):
+    def setUp(self):
+        self.service = GameService()
+        self.job = Job(
+            job_id="job-test",
+            demand_main="Human",
+            demand_level=1,
+            demand_sub="VAGINAL",
+            demand_sub_level=0,
+            pay=50,
+            difficulty=1,
+        )
+
+    def _make_girl(self, lust: int) -> Girl:
+        girl = Girl(
+            uid="g-test",
+            base_id="base",
+            name="Test Girl",
+            rarity="R",
+            lust=lust,
+        )
+        for name in girl.skills:
+            girl.skills[name]["level"] = 2 if name == "Human" else 0
+        return girl
+
+    def test_brothel_lust_modifier_updates_lust_gate(self):
+        girl = self._make_girl(lust=9)
+        baseline = self.service.evaluate_job(girl, self.job)
+        self.assertFalse(baseline["lust_ok"])
+        self.assertFalse(baseline["can_attempt"])
+
+        brothel = BrothelState(comfort_level=10, morale=100, cleanliness=90)
+        adjusted = self.service.evaluate_job(girl, self.job, brothel)
+
+        self.assertLess(adjusted["lust_cost"], baseline["lust_cost"])
+        self.assertTrue(adjusted["lust_ok"])
+        self.assertTrue(adjusted["can_attempt"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- recompute lust eligibility in `GameService.evaluate_job` after the brothel adjusts lust cost
- ensure the job attempt flag reflects the updated lust check
- cover the behaviour with a unit test verifying reduced lust cost allows the job

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9cdcadc008322b9a0351bf96427e1