### PR TITLE
Ensure mentorship market options keep girl identity

### DIFF
--- a/src/game/views.py
+++ b/src/game/views.py
@@ -218,30 +218,31 @@ class MarketWorkView(discord.ui.View):
         if not player or not player.girls:
             return options
         for g in player.girls[:24]:
-            label = f"{g.name} ({g.uid})"
+            option_label = f"{g.name} ({g.uid})"
             lust_ratio = g.lust / g.lust_max if g.lust_max else 0.0
             mood = lust_state_label(lust_ratio)
             mood_icon = lust_state_icon(lust_ratio)
-            desc = (
+            base_desc = (
                 f"{mood_icon} {EMOJI_HEART} {g.health}/{g.health_max} • "
                 f"{EMOJI_ENERGY} {g.stamina}/{g.stamina_max} • "
                 f"{EMOJI_LUST} {g.lust}/{g.lust_max} [{mood}]"
             )
+            desc = base_desc
             emoji = EMOJI_GIRL
             if brothel and brothel.training_for(g.uid):
-                desc = f"📘 Training • {desc}"
+                desc = f"📘 Training • {base_desc}"
                 emoji = "📘"
             elif g.mentorship_bonus > 0:
-                icon, label = self._training_focus_display(
+                icon, focus_label = self._training_focus_display(
                     g.mentorship_focus_type, g.mentorship_focus
                 )
-                desc = (
-                    f"📈 {icon} {label} +{int(g.mentorship_bonus * 100)}% • "
-                    f"{desc}"
+                mentorship_text = (
+                    f"📈 {icon} {focus_label} +{int(g.mentorship_bonus * 100)}%"
                 )
+                desc = f"{option_label} • {mentorship_text} • {base_desc}"
             options.append(
                 discord.SelectOption(
-                    label=label[:100],
+                    label=option_label[:100],
                     value=g.uid,
                     description=desc[:100],
                     default=g.uid == self.selected_girl_uid,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,31 @@
+import unittest
+
+from src.game.views import MarketWorkView
+from src.models import Girl, Player
+
+
+class MarketWorkViewOptionTests(unittest.TestCase):
+    def test_mentorship_option_includes_name_and_uid(self):
+        girl = Girl(uid="g-mentor", base_id="base", name="Mentor", rarity="R")
+        girl.mentorship_bonus = 0.25
+        girl.mentorship_focus_type = "main"
+        girl.mentorship_focus = "Human"
+
+        player = Player(user_id=123, girls=[girl])
+        brothel = player.ensure_brothel()
+
+        view = MarketWorkView.__new__(MarketWorkView)
+        view.selected_girl_uid = None
+
+        options = view._build_girl_options(player, brothel)
+        girl_option = next(opt for opt in options if opt.value == girl.uid)
+
+        self.assertIn(girl.name, girl_option.label)
+        self.assertIn(girl.uid, girl_option.label)
+        self.assertIsNotNone(girl_option.description)
+        self.assertIn(girl.name, girl_option.description)
+        self.assertIn(girl.uid, girl_option.description)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the original girl label when adding mentorship bonus details
- include mentorship bonus information in the option description while preserving the name/UID
- add a regression test covering mentorship options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d3b96fe88322a124dd29bc7b14c7