### PR TITLE
Ensure mentorship options keep name and UID

### DIFF
--- a/src/game/views.py
+++ b/src/game/views.py
@@ -255,30 +255,32 @@ class MarketWorkView(discord.ui.View):
         start = self.girl_page * page_size
         end = start + page_size
         for g in player.girls[start:end]:
-            label = f"{g.name} ({g.uid})"
+            option_label = f"{g.name} ({g.uid})"
             lust_ratio = g.lust / g.lust_max if g.lust_max else 0.0
             mood = lust_state_label(lust_ratio)
             mood_icon = lust_state_icon(lust_ratio)
-            desc = (
+            stats_desc = (
                 f"{mood_icon} {EMOJI_HEART} {g.health}/{g.health_max} • "
                 f"{EMOJI_ENERGY} {g.stamina}/{g.stamina_max} • "
                 f"{EMOJI_LUST} {g.lust}/{g.lust_max} [{mood}]"
             )
             emoji = EMOJI_GIRL
             if brothel and brothel.training_for(g.uid):
-                desc = f"📘 Training • {desc}"
+                desc = f"📘 Training • {option_label} • {stats_desc}"
                 emoji = "📘"
             elif g.mentorship_bonus > 0:
-                icon, label = self._training_focus_display(
+                focus_icon, focus_label = self._training_focus_display(
                     g.mentorship_focus_type, g.mentorship_focus
                 )
-                desc = (
-                    f"📈 {icon} {label} +{int(g.mentorship_bonus * 100)}% • "
-                    f"{desc}"
+                mentorship_text = (
+                    f"📈 {focus_icon} {focus_label} +{int(g.mentorship_bonus * 100)}%"
                 )
+                desc = " • ".join([option_label, mentorship_text, stats_desc])
+            else:
+                desc = " • ".join([option_label, stats_desc])
             options.append(
                 discord.SelectOption(
-                    label=label[:100],
+                    label=option_label[:100],
                     value=g.uid,
                     description=desc[:100],
                     default=g.uid == self.selected_girl_uid,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -46,5 +46,37 @@ class MarketWorkViewPaginationTests(unittest.TestCase):
         self.assertTrue(self.view.girl_next_page_btn.disabled)
 
 
+class MarketWorkViewMentorshipTests(unittest.TestCase):
+    def setUp(self):
+        self.player = Player(user_id=456)
+        mentor = Girl(uid="g777", base_id="base", name="Mentor Girl", rarity="SR")
+        mentor.mentorship_bonus = 0.15
+        mentor.mentorship_focus_type = "main"
+        mentor.mentorship_focus = "charm"
+        self.player.girls = [mentor]
+        self.market = Market(user_id=456, jobs=[])
+
+        async def _create_view():
+            return MarketWorkView(
+                user_id=456,
+                invoker_id=456,
+                forced_level=None,
+                player=self.player,
+                market=self.market,
+            )
+
+        self.view = asyncio.run(_create_view())
+
+    def test_mentorship_option_includes_name_and_uid(self):
+        options_by_value = {opt.value: opt for opt in self.view.girl_select.options}
+        girl_option = options_by_value["g777"]
+
+        self.assertIn("Mentor Girl", girl_option.label)
+        self.assertIn("g777", girl_option.label)
+        self.assertIn("Mentor Girl", girl_option.description)
+        self.assertIn("g777", girl_option.description)
+        self.assertIn("+15%", girl_option.description)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- keep the original girl name/UID label when adding mentorship focus details in the market preview
- include mentorship bonus information in the option description while retaining the girl's identity
- add a regression test covering mentorship bonuses in the girl selection options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d5759924832289492925d7103373