### PR TITLE
Require minimum investment for brothel promotion

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -26,6 +26,7 @@ from ..models import (
     SUB_SKILLS,
     PREF_BLOCKED,
     RARITY_COLORS,
+    PROMOTE_COINS_PER_RENOWN,
     make_bar,
     market_level_from_rep,
 )
@@ -304,10 +305,22 @@ class Core(commands.Cog):
                     f"{EMOJI_COIN} Used {result['pool_used']} from upkeep reserve."
                 )
         elif action_val == "promote":
+            prev_renown = brothel.renown
             result = brothel.promote(invest)
-            notes.append(
-                f"{EMOJI_POPULARITY} Renown +{result['renown']} (now {brothel.renown})."
-            )
+            renown_gain = result.get("renown", 0)
+            if renown_gain > 0:
+                notes.append(
+                    f"{EMOJI_POPULARITY} Renown +{renown_gain} (now {brothel.renown})."
+                )
+            elif prev_renown >= 500:
+                notes.append(
+                    f"{EMOJI_POPULARITY} Renown is already maxed at {brothel.renown}."
+                )
+            else:
+                notes.append(
+                    f"{EMOJI_POPULARITY} Investment too small to gain renown. Spend at least "
+                    f"{PROMOTE_COINS_PER_RENOWN} coins for +1."
+                )
             if result.get("morale"):
                 notes.append(
                     f"{EMOJI_MORALE} Morale +{result['morale']} (now {brothel.morale}/100)."

--- a/src/models.py
+++ b/src/models.py
@@ -15,6 +15,8 @@ BROTHEL_FACILITY_NAMES: Tuple[str, ...] = ("comfort", "hygiene", "security", "al
 RARITY_WEIGHTS = {"R": 70, "SR": 20, "SSR": 9, "UR": 1}
 RARITY_COLORS  = {"R": 0x9fa6b2, "SR": 0x60a5fa, "SSR": 0xf59e0b, "UR": 0x8b5cf6}
 
+PROMOTE_COINS_PER_RENOWN = 5
+
 # Preferences for skills/subskills
 PREF_OPEN    = "true"   # open for training
 PREF_BLOCKED = "false"  # blocked (girl refuses jobs using it)
@@ -623,7 +625,7 @@ class BrothelState(BaseModel):
         coins = max(0, int(coins))
         if coins <= 0:
             return {"renown": 0, "morale": 0}
-        gained = min(500 - self.renown, max(1, coins // 5))
+        gained = min(500 - self.renown, coins // PROMOTE_COINS_PER_RENOWN)
         morale = min(100 - self.morale, max(0, coins // 18))
         self.renown += gained
         self.morale += morale

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,23 @@
+import unittest
+
+from src.models import BrothelState, PROMOTE_COINS_PER_RENOWN
+
+
+class BrothelPromotionTests(unittest.TestCase):
+    def test_small_investment_does_not_grant_renown(self):
+        brothel = BrothelState(renown=120, morale=70)
+        result = brothel.promote(PROMOTE_COINS_PER_RENOWN - 1)
+
+        self.assertEqual(result["renown"], 0)
+        self.assertEqual(brothel.renown, 120)
+
+    def test_threshold_investment_grants_renown(self):
+        brothel = BrothelState(renown=120, morale=70)
+        result = brothel.promote(PROMOTE_COINS_PER_RENOWN)
+
+        self.assertEqual(result["renown"], 1)
+        self.assertEqual(brothel.renown, 121)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require brothel promotions to use a fixed coin-to-renown ratio and expose the constant
- adjust /brothel promote messaging to explain when promotions don't grant renown
- add unit tests confirming small promotion spends no longer grant free renown

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9decc7b188322affdb07c0120708f