### PR TITLE
Support configurable paths and market settings

### DIFF
--- a/src/assets_util.py
+++ b/src/assets_util.py
@@ -6,8 +6,30 @@ from typing import Optional
 
 # Base: <project_root>/assets/girls
 # This file is at: <root>/src/assets_util.py
-BASE_DIR = Path(__file__).resolve().parents[1]          
-GIRLS_ASSETS = BASE_DIR / "assets" / "girls"            
+BASE_DIR = Path(__file__).resolve().parents[1]
+_DEFAULT_GIRLS_ASSETS = BASE_DIR / "assets" / "girls"
+_GIRLS_ASSETS = _DEFAULT_GIRLS_ASSETS
+
+
+def set_assets_dir(path: Path | str | None) -> None:
+    """Override the base directory used to look up girl assets."""
+
+    global _GIRLS_ASSETS
+    if path is None:
+        _GIRLS_ASSETS = _DEFAULT_GIRLS_ASSETS
+        return
+    new_path = Path(path).expanduser()
+    try:
+        _GIRLS_ASSETS = new_path.resolve()
+    except OSError:
+        # Path may not exist yet — keep the normalized version without resolve().
+        _GIRLS_ASSETS = new_path
+
+
+def get_assets_dir() -> Path:
+    """Return the currently configured assets directory."""
+
+    return _GIRLS_ASSETS
 
 def _slug(s: str) -> str:
     """Make safe lowercase slug for filesystem paths."""
@@ -26,11 +48,13 @@ def profile_image_path(girl_name: str, base_id: str = "") -> Optional[str]:
     name_slug = _slug(girl_name)
     base_slug = _slug(base_id) if base_id else None
 
+    base_path = get_assets_dir()
+
     candidates = []
     if name_slug:
-        candidates.append(GIRLS_ASSETS / name_slug / f"{name_slug}_profile.png")
+        candidates.append(base_path / name_slug / f"{name_slug}_profile.png")
     if base_slug and base_slug != name_slug:
-        candidates.append(GIRLS_ASSETS / base_slug / f"{base_slug}_profile.png")
+        candidates.append(base_path / base_slug / f"{base_slug}_profile.png")
 
     for p in candidates:
         if p.exists():
@@ -51,11 +75,13 @@ def action_image_path(girl_name: str, base_id: str, main_skill: str, sub_skill: 
     main = _slug(main_skill)
     sub = _slug(sub_skill)
 
+    base_path = get_assets_dir()
+
     candidates = []
     if name_slug:
-        candidates.append(GIRLS_ASSETS / name_slug / main / f"{sub}.png")
+        candidates.append(base_path / name_slug / main / f"{sub}.png")
     if base_slug and base_slug != name_slug:
-        candidates.append(GIRLS_ASSETS / base_slug / main / f"{sub}.png")
+        candidates.append(base_path / base_slug / main / f"{sub}.png")
 
     for p in candidates:
         if p.exists():
@@ -72,12 +98,14 @@ def pregnant_profile_image_path(girl_name: str, base_id: str = "") -> Optional[s
     name_slug = _slug(girl_name)
     base_slug = _slug(base_id) if base_id else None
 
+    base_path = get_assets_dir()
+
     candidates = []
     if name_slug:
-        candidates.append(GIRLS_ASSETS / name_slug / f"{name_slug}_pregnant.png")
-        candidates.append(GIRLS_ASSETS / name_slug / "pregnant.png")
+        candidates.append(base_path / name_slug / f"{name_slug}_pregnant.png")
+        candidates.append(base_path / name_slug / "pregnant.png")
     if base_slug and base_slug != name_slug:
-        candidates.append(GIRLS_ASSETS / base_slug / f"{base_slug}_pregnant.png")
+        candidates.append(base_path / base_slug / f"{base_slug}_pregnant.png")
 
     for p in candidates:
         if p.exists():

--- a/src/game/repository.py
+++ b/src/game/repository.py
@@ -10,17 +10,96 @@ from typing import Iterable, Optional
 class DataStore:
     """Utility wrapper around the project's data directories."""
 
-    def __init__(self, base_dir: Path | None = None):
+    def __init__(self, base_dir: Path | str | None = None):
+        default_base = Path(__file__).resolve().parents[2]
         if base_dir is None:
-            base_dir = Path(__file__).resolve().parents[2]
-        self.base_dir = base_dir
+            resolved_base = default_base
+        else:
+            resolved_base = Path(base_dir).expanduser()
+            if not resolved_base.is_absolute():
+                resolved_base = default_base / resolved_base
+        self.base_dir = resolved_base.resolve()
         self.data_dir = self.base_dir / "data"
         self.users_dir = self.data_dir / "users"
         self.market_dir = self.data_dir / "markets"
         self.catalog_path = self.data_dir / "girls_catalog.json"
-        self.data_dir.mkdir(exist_ok=True)
-        self.users_dir.mkdir(exist_ok=True)
-        self.market_dir.mkdir(exist_ok=True)
+        self.assets_dir = self.base_dir / "assets" / "girls"
+        self._ensure_dirs()
+
+    def _coerce_path(self, value: Path | str, relative_to: Path) -> Path:
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            path = relative_to / path
+        return path.resolve()
+
+    def _ensure_dirs(self) -> None:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.users_dir.mkdir(parents=True, exist_ok=True)
+        self.market_dir.mkdir(parents=True, exist_ok=True)
+        catalog_parent = self.catalog_path.parent
+        catalog_parent.mkdir(parents=True, exist_ok=True)
+
+    def configure_paths(self, paths: dict | None) -> None:
+        """Apply path overrides from configuration."""
+
+        if not isinstance(paths, dict):
+            self._ensure_dirs()
+            return
+
+        base_override = paths.get("base_dir")
+        if base_override is not None:
+            self.base_dir = self._coerce_path(base_override, self.base_dir)
+
+        base_dir = self.base_dir
+
+        data_dir_value = paths.get("data_dir")
+        users_dir_value = paths.get("users_dir") or paths.get("users")
+        markets_dir_value = paths.get("markets_dir") or paths.get("markets")
+        catalog_value = paths.get("catalog")
+        assets_value = paths.get("assets")
+
+        data_dir = base_dir / "data"
+        users_dir = data_dir / "users"
+        markets_dir = data_dir / "markets"
+
+        if data_dir_value is not None:
+            candidate = self._coerce_path(data_dir_value, base_dir)
+            lowered = candidate.name.lower()
+            if lowered == "users" and users_dir_value is None:
+                users_dir = candidate
+                data_dir = candidate.parent
+                if markets_dir_value is None:
+                    markets_dir = data_dir / "markets"
+            elif lowered == "markets" and markets_dir_value is None:
+                markets_dir = candidate
+                data_dir = candidate.parent
+                if users_dir_value is None:
+                    users_dir = data_dir / "users"
+            else:
+                data_dir = candidate
+                users_dir = candidate / "users"
+                markets_dir = candidate / "markets"
+
+        if users_dir_value is not None:
+            users_dir = self._coerce_path(users_dir_value, base_dir)
+        if markets_dir_value is not None:
+            markets_dir = self._coerce_path(markets_dir_value, base_dir)
+
+        self.data_dir = data_dir
+        self.users_dir = users_dir
+        self.market_dir = markets_dir
+
+        if catalog_value is not None:
+            self.catalog_path = self._coerce_path(catalog_value, base_dir)
+        else:
+            self.catalog_path = self.data_dir / "girls_catalog.json"
+
+        if assets_value is not None:
+            self.assets_dir = self._coerce_path(assets_value, base_dir)
+        else:
+            self.assets_dir = self.base_dir / "assets" / "girls"
+
+        self._ensure_dirs()
 
     # ------------------------------------------------------------------
     # Generic JSON helpers

--- a/src/storage.py
+++ b/src/storage.py
@@ -91,3 +91,7 @@ def brothel_leaderboard(limit: int = 10):
 
 def girl_leaderboard(limit: int = 10):
     return _SERVICE.gather_girl_top(limit)
+
+
+def get_config() -> dict:
+    return _SERVICE.get_config()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,8 @@
 import unittest
+from unittest.mock import MagicMock, patch, call
 from types import SimpleNamespace
 
-from src.cogs.core import normalize_brothel_action
+from src.cogs.core import Core, normalize_brothel_action
 
 
 class BrothelActionNormalizationTests(unittest.TestCase):
@@ -15,6 +16,19 @@ class BrothelActionNormalizationTests(unittest.TestCase):
 
     def test_none_choice_defaults_to_view(self):
         self.assertEqual(normalize_brothel_action(None), "view")
+
+
+class MarketRefresherConfigTests(unittest.TestCase):
+    def test_refresh_interval_uses_config_value(self):
+        with patch("src.cogs.core.get_config", return_value={"market": {"refresh_minutes": 7}}), \
+            patch("discord.ext.tasks.Loop.change_interval") as mock_change_interval, \
+            patch("discord.ext.tasks.Loop.start") as mock_start:
+            core = Core(MagicMock())
+            self.assertGreaterEqual(mock_change_interval.call_count, 1)
+            self.assertEqual(mock_change_interval.call_args_list[-1], call(minutes=7.0))
+            mock_start.assert_called_once()
+            self.assertEqual(core.market_refresh_minutes, 7.0)
+            core.cog_unload()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow the data store and asset lookup helpers to honour configuration-provided directories, including overriding the girls asset root
- apply configuration when loading the game service so market generation respects jobs_per_level, expose the config via storage, and drive the core market refresher interval from refresh_minutes
- add unit tests covering the configurable paths, market job counts, and refresher interval behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9decd09008322ae33faa801123476