### PR TITLE
Refactor brothel and train commands

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
+import asyncio
 import unittest
-from unittest.mock import MagicMock, patch, call
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from src.cogs.core import Core, normalize_brothel_action
 
@@ -29,6 +30,110 @@ class MarketRefresherConfigTests(unittest.TestCase):
             mock_start.assert_called_once()
             self.assertEqual(core.market_refresh_minutes, 7.0)
             core.cog_unload()
+
+
+def test_brothel_error_saves_player(monkeypatch):
+    core = Core.__new__(Core)
+    core.bot = MagicMock()
+
+    player = MagicMock()
+    player.currency = 100
+    player.girls = []
+    player.renown = 0
+
+    brothel = MagicMock()
+    brothel.renown = 25
+    brothel.apply_decay = MagicMock()
+    player.ensure_brothel.return_value = brothel
+
+    monkeypatch.setattr("src.cogs.core.load_player", lambda _: player)
+    save_mock = MagicMock()
+    monkeypatch.setattr("src.cogs.core.save_player", save_mock)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, display_name="Tester"),
+        response=SimpleNamespace(
+            is_done=MagicMock(return_value=False),
+            send_message=AsyncMock(),
+        ),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    asyncio.run(
+        core.brothel.callback(
+            core,
+            interaction,
+            action=SimpleNamespace(value="promote"),
+            facility=None,
+            coins=0,
+        )
+    )
+
+    save_mock.assert_called_once_with(player)
+
+
+def test_train_list_saves_player_when_empty(monkeypatch):
+    core = Core.__new__(Core)
+    core.bot = MagicMock()
+
+    player = MagicMock()
+    player.currency = 0
+    player.girls = []
+    player.renown = 0
+
+    brothel = MagicMock()
+    brothel.renown = 10
+    brothel.apply_decay = MagicMock()
+    brothel.training = []
+    player.ensure_brothel.return_value = brothel
+
+    monkeypatch.setattr("src.cogs.core.load_player", lambda _: player)
+    save_mock = MagicMock()
+    monkeypatch.setattr("src.cogs.core.save_player", save_mock)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=2, display_name="Trainer"),
+        response=SimpleNamespace(
+            is_done=MagicMock(return_value=False),
+            send_message=AsyncMock(),
+        ),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    asyncio.run(
+        core.train.callback(
+            core,
+            interaction,
+            SimpleNamespace(value="list"),
+        )
+    )
+
+    save_mock.assert_called_once_with(player)
+
+
+def test_resolve_training_focus_infers_main_choice():
+    focus_type, focus_name, error = Core._resolve_training_focus(
+        None,
+        SimpleNamespace(value="Human"),
+        None,
+    )
+    assert error is None
+    assert focus_type == "main"
+    assert focus_name == "Human"
+
+
+def test_resolve_training_focus_conflict_returns_error():
+    _, _, error = Core._resolve_training_focus(
+        None,
+        SimpleNamespace(value="Human"),
+        SimpleNamespace(value="VAGINAL"),
+    )
+    assert error == "Select either a main skill or a sub-skill, not both."
+
+
+def test_format_training_focus_labels():
+    assert Core._format_training_focus("sub", "VAGINAL") == "Vaginal (sub-skill)"
+    assert Core._format_training_focus(None, None) == "general technique"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- centralize Discord response handling and player preparation helpers used by `/brothel` and `/train`
- refactor the `/brothel` command into action-specific handlers that ensure coins, notes, and state persistence are consistent
- restructure the `/train` command into dedicated list/assign/finish helpers with clearer validation and add regression tests for persistence and focus utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5862d898832294ff244845a76943