### PR TITLE
Remove renown cap

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -278,17 +278,12 @@ class Core(commands.Cog):
         return notes
 
     def _brothel_promote_notes(self, brothel, invest: int) -> list[str]:
-        prev_renown = brothel.renown
         result = brothel.promote(invest)
         renown_gain = int(result.get("renown", 0))
         notes: list[str] = []
         if renown_gain > 0:
             notes.append(
                 f"{EMOJI_POPULARITY} Renown +{renown_gain} (now {brothel.renown})."
-            )
-        elif prev_renown >= 500:
-            notes.append(
-                f"{EMOJI_POPULARITY} Renown is already maxed at {brothel.renown}."
             )
         else:
             notes.append(

--- a/src/game/services.py
+++ b/src/game/services.py
@@ -736,7 +736,7 @@ class GameService:
             renown_delta += 6 + job.difficulty * 2
         else:
             renown_delta -= max(1, 2 + job.difficulty)
-        player.renown = max(0, min(500, player.renown + renown_delta))
+        player.renown = max(0, player.renown + renown_delta)
         brothel.renown = player.renown
 
         if sub_name == "VAGINAL" and not girl.pregnant:
@@ -827,7 +827,7 @@ class GameService:
         player.girls = [g for g in player.girls if g.uid != girl_uid]
 
         renown_gain_by_rarity = {"R": 1, "SR": 2, "SSR": 4, "UR": 6}
-        player.renown = max(0, min(500, player.renown + renown_gain_by_rarity.get(girl.rarity, 1)))
+        player.renown = max(0, player.renown + renown_gain_by_rarity.get(girl.rarity, 1))
         brothel.renown = player.renown
 
         return {

--- a/src/models.py
+++ b/src/models.py
@@ -477,7 +477,7 @@ class BrothelState(BaseModel):
 
         self.cleanliness = min(100, max(0, int(self.cleanliness)))
         self.morale = min(100, max(10, int(self.morale)))
-        self.renown = min(500, max(0, int(self.renown)))
+        self.renown = max(0, int(self.renown))
         self.rooms = max(1, int(self.rooms))
         self.upkeep_pool = min(10000, max(0, int(self.upkeep_pool)))
         self.room_progress = max(0, int(self.room_progress))
@@ -572,7 +572,7 @@ class BrothelState(BaseModel):
         if self.cleanliness < 50:
             self.renown = max(0, self.renown - max(1, decay // 3))
         else:
-            self.renown = min(500, self.renown + int(decay // 5))
+            self.renown += int(decay // 5)
 
         remainder = elapsed % 900
         self.last_tick_ts = now - remainder
@@ -625,7 +625,7 @@ class BrothelState(BaseModel):
         coins = max(0, int(coins))
         if coins <= 0:
             return {"renown": 0, "morale": 0}
-        gained = min(500 - self.renown, coins // PROMOTE_COINS_PER_RENOWN)
+        gained = max(0, coins // PROMOTE_COINS_PER_RENOWN)
         morale = min(100 - self.morale, max(0, coins // 18))
         self.renown += gained
         self.morale += morale


### PR DESCRIPTION
## Summary
- allow brothel renown to grow beyond the previous 500 point cap
- adjust promotion, maintenance, and service flows to avoid clamping renown gains
- update promotion messaging now that renown is uncapped

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca623d3e24832286b1409f0a8f97dc