### PR TITLE
Scale hygiene benefits across brothel upkeep

### DIFF
--- a/src/game/embeds.py
+++ b/src/game/embeds.py
@@ -73,7 +73,18 @@ def brothel_facility_lines(brothel: BrothelState) -> list[str]:
         icon, label = FACILITY_INFO[key]
         lvl, xp, need = brothel.facility_progress(key)
         bar = make_bar(xp, need, length=8)
-        lines.append(f"{icon} {label} L{lvl} [{bar}] {xp}/{need}")
+        line = f"{icon} {label} L{lvl} [{bar}] {xp}/{need}"
+        if key == "hygiene":
+            decay_reduction = int(round(brothel.hygiene_reduction_ratio() * 100))
+            upkeep_bonus = int(round((brothel.hygiene_restoration_multiplier() - 1.0) * 100))
+            extras: list[str] = []
+            if decay_reduction > 0:
+                extras.append(f"-{decay_reduction}% decay")
+            if upkeep_bonus > 0:
+                extras.append(f"+{upkeep_bonus}% upkeep")
+            if extras:
+                line = f"{line} • {' / '.join(extras)}"
+        lines.append(line)
     return lines
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.models import BrothelState, PROMOTE_COINS_PER_RENOWN
+from src.models import BrothelState, Job, PROMOTE_COINS_PER_RENOWN, now_ts
 
 
 class BrothelPromotionTests(unittest.TestCase):
@@ -17,6 +17,70 @@ class BrothelPromotionTests(unittest.TestCase):
 
         self.assertEqual(result["renown"], 1)
         self.assertEqual(brothel.renown, 121)
+
+
+class BrothelHygieneTests(unittest.TestCase):
+    def test_hygiene_mitigates_decay_and_penalties(self):
+        ticks = 6
+        reference_ts = now_ts() - 900 * ticks
+        low = BrothelState(
+            hygiene_level=1,
+            cleanliness=35,
+            morale=70,
+            renown=120,
+            last_tick_ts=reference_ts,
+        )
+        high = BrothelState(
+            hygiene_level=8,
+            cleanliness=35,
+            morale=70,
+            renown=120,
+            last_tick_ts=reference_ts,
+        )
+
+        low.apply_decay()
+        high.apply_decay()
+
+        low_loss = 35 - low.cleanliness
+        high_loss = 35 - high.cleanliness
+
+        self.assertGreaterEqual(high.cleanliness, low.cleanliness)
+        self.assertLessEqual(high_loss, low_loss)
+        self.assertGreaterEqual(high.morale, low.morale)
+        self.assertGreaterEqual(high.renown, low.renown)
+
+    def test_hygiene_improves_maintenance(self):
+        low = BrothelState(hygiene_level=1, cleanliness=40, upkeep_pool=0)
+        high = BrothelState(hygiene_level=7, cleanliness=40, upkeep_pool=0)
+
+        low_result = low.maintain(120)
+        high_result = high.maintain(120)
+
+        self.assertGreater(high_result["cleanliness"], low_result["cleanliness"])
+        self.assertGreaterEqual(high.cleanliness, low.cleanliness)
+        self.assertGreaterEqual(high_result["morale"], low_result["morale"])
+
+    def test_hygiene_reduces_job_wear(self):
+        job = Job(
+            job_id="test",
+            demand_main="Human",
+            demand_level=1,
+            demand_sub="VAGINAL",
+            demand_sub_level=1,
+            pay=100,
+            difficulty=3,
+        )
+        low = BrothelState(hygiene_level=1, cleanliness=85)
+        high = BrothelState(hygiene_level=9, cleanliness=85)
+
+        low.register_job_outcome(success=True, injured=True, job=job, reward=200)
+        high.register_job_outcome(success=True, injured=True, job=job, reward=200)
+
+        low_loss = 85 - low.cleanliness
+        high_loss = 85 - high.cleanliness
+
+        self.assertGreaterEqual(high.cleanliness, low.cleanliness)
+        self.assertLessEqual(high_loss, low_loss)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add hygiene mitigation/restoration helpers so decay, morale, renown and job wear scale with the facility level
- boost cleaning actions with hygiene upgrades and surface the bonuses in the brothel facilities embed
- extend model tests to confirm hygiene level reduces decay, eases upkeep, and limits job wear

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca6b0b972883228c6a8fa3ed4e97ab