### PR TITLE
Preserve renown when ensuring brothel state

### DIFF
--- a/src/game/services.py
+++ b/src/game/services.py
@@ -278,7 +278,9 @@ class GameService:
 
         player = Player(user_id=uid, currency=starter_coins, girls=[])
         brothel = player.ensure_brothel()
-        player.renown = brothel.renown
+        starter_renown = brothel.renown if brothel.renown > 0 else BrothelState().renown
+        player.renown = starter_renown
+        brothel.renown = starter_renown
 
         girl_uid = self._alloc_girl_uid(base_entry["id"], player.girls)
         girl = self._make_girl_from_catalog_entry(base_entry, uid=girl_uid)

--- a/src/models.py
+++ b/src/models.py
@@ -808,7 +808,15 @@ class Player(BaseModel):
             else:
                 self.brothel = BrothelState()
         self.brothel.ensure_bounds()
-        self.brothel.sync_renown(self)
+        brothel_renown = int(getattr(self.brothel, "renown", 0) or 0)
+        player_renown = int(getattr(self, "renown", 0) or 0)
+
+        if player_renown <= 0 and brothel_renown > 0:
+            self.renown = brothel_renown
+            player_renown = brothel_renown
+
+        if player_renown > 0:
+            self.brothel.renown = player_renown
         return self.brothel
 
     @property


### PR DESCRIPTION
## Summary
- restore player renown from the brothel when ensure_brothel loads legacy data and only sync back when a positive value exists
- keep starter pack profiles at the default renown rather than zeroing their rating
- cover the renown handling with new unit tests for fresh and legacy player data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca984b8f788322b97b447d88d5e575