### PR TITLE
Adjust training bonus scaling and enforce minimum duration

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,5 +136,93 @@ def test_format_training_focus_labels():
     assert Core._format_training_focus(None, None) == "general technique"
 
 
+def test_training_bonus_requires_time(monkeypatch):
+    now = 1_000_000
+    monkeypatch.setattr("src.cogs.core.time.time", lambda: now)
+
+    mentor = SimpleNamespace(
+        level=8,
+        vitality_level=4,
+        skills={"A": {"level": 4}, "B": {"level": 3}},
+        subskills={"x": {"level": 2}},
+    )
+    student = SimpleNamespace(
+        level=2,
+        vitality_level=1,
+        skills={"A": {"level": 1}},
+        subskills={},
+    )
+
+    short_assignment = SimpleNamespace(since_ts=now - 120)
+    long_assignment = SimpleNamespace(since_ts=now - 3600)
+
+    short_bonus = Core._calculate_training_bonus(short_assignment, mentor, student)
+    long_bonus = Core._calculate_training_bonus(long_assignment, mentor, student)
+
+    assert short_bonus < 0.05
+    assert long_bonus > short_bonus * 5
+
+
+def test_train_finish_refuses_short_sessions(monkeypatch):
+    now = 2_000_000
+    monkeypatch.setattr("src.cogs.core.time.time", lambda: now)
+
+    core = Core.__new__(Core)
+    core.bot = MagicMock()
+
+    player = MagicMock()
+    mentor_girl = MagicMock()
+    mentor_girl.uid = "mentor"
+    mentor_girl.name = "Mentor"
+
+    student_girl = MagicMock()
+    student_girl.uid = "student"
+    student_girl.name = "Student"
+
+    player.get_girl.side_effect = lambda uid: {
+        "mentor": mentor_girl,
+        "student": student_girl,
+    }.get(uid)
+
+    assignment = SimpleNamespace(
+        mentor_uid="mentor",
+        student_uid="student",
+        since_ts=now - 60,
+        focus_type="main",
+        focus="Human",
+    )
+
+    brothel = MagicMock()
+    brothel.training_for.return_value = assignment
+    brothel.stop_training = MagicMock()
+
+    save_mock = MagicMock()
+    monkeypatch.setattr("src.cogs.core.save_player", save_mock)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=3, display_name="Manager"),
+        response=SimpleNamespace(
+            is_done=MagicMock(return_value=False),
+            send_message=AsyncMock(),
+        ),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    asyncio.run(
+        core._handle_train_finish(
+            interaction,
+            player,
+            brothel,
+            mentor=None,
+            student="student",
+        )
+    )
+
+    brothel.stop_training.assert_not_called()
+    student_girl.grant_training_bonus.assert_not_called()
+    assert "too short" in interaction.response.send_message.await_args.kwargs["content"].lower()
+    save_mock.assert_called_once_with(player)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- scale mentorship bonus gap contributions by elapsed training time and cap short sessions
- block finishing trainings that run for less than the minimum duration to prevent instant bonuses
- cover time-dependent bonuses and finish handler behavior with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa33910848322b35acf1456a92c2d