### PR TITLE
Fix slash command sync response and adjust training view layout

### DIFF
--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -87,6 +87,8 @@ class Admin(commands.Cog):
             )
             return
 
+        await interaction.response.defer(thinking=True, ephemeral=True)
+
         report = await self._sync_commands(report_changes=True)
         message: str
         if report is None:
@@ -105,7 +107,7 @@ class Admin(commands.Cog):
                         f"Invalid guild id {invalid_value!r}; globally synced {count} commands instead."
                     )
 
-        await interaction.response.send_message(message, ephemeral=True)
+        await interaction.followup.send(message, ephemeral=True)
 
     @app_commands.command(name="invite", description="Get bot invite link (applications.commands + bot)")
     async def invite(self, interaction: discord.Interaction) -> None:

--- a/src/game/interactive.py
+++ b/src/game/interactive.py
@@ -754,7 +754,7 @@ class TrainingManageView(discord.ui.View):
             self.student_page += 1
         await self._refresh(interaction, update_embed=False)
 
-    @discord.ui.button(label="◀ Page", style=discord.ButtonStyle.secondary, row=0)
+    @discord.ui.button(label="◀ Page", style=discord.ButtonStyle.secondary, row=4)
     async def page_prev(
         self,
         interaction: discord.Interaction,
@@ -766,7 +766,7 @@ class TrainingManageView(discord.ui.View):
             self.page_index -= 1
         await self._refresh(interaction, update_embed=True)
 
-    @discord.ui.button(label="Page ▶", style=discord.ButtonStyle.secondary, row=0)
+    @discord.ui.button(label="Page ▶", style=discord.ButtonStyle.secondary, row=4)
     async def page_next(
         self,
         interaction: discord.Interaction,
@@ -778,7 +778,7 @@ class TrainingManageView(discord.ui.View):
             self.page_index += 1
         await self._refresh(interaction, update_embed=True)
 
-    @discord.ui.button(label="Roster ◀", style=discord.ButtonStyle.secondary, row=0)
+    @discord.ui.button(label="Roster ◀", style=discord.ButtonStyle.secondary, row=4)
     async def roster_prev(
         self,
         interaction: discord.Interaction,
@@ -795,7 +795,7 @@ class TrainingManageView(discord.ui.View):
             self.roster_page -= 1
         await self._refresh(interaction, update_embed=True)
 
-    @discord.ui.button(label="Roster ▶", style=discord.ButtonStyle.secondary, row=0)
+    @discord.ui.button(label="Roster ▶", style=discord.ButtonStyle.secondary, row=4)
     async def roster_next(
         self,
         interaction: discord.Interaction,


### PR DESCRIPTION
## Summary
- defer the admin sync command response and send the result via followup to avoid unknown interaction errors
- move training pagination and roster navigation buttons to the bottom row to satisfy Discord's component width limits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf15419308322b7d3302e24dc92f5