### PR TITLE
Restrict skill normalization to known names

### DIFF
--- a/src/game/services.py
+++ b/src/game/services.py
@@ -156,12 +156,12 @@ class GameService:
             skills_raw = girl.get("skills") or {}
             if not isinstance(skills_raw, dict):
                 skills_raw = {}
-            girl["skills"] = normalize_skill_map(skills_raw)
+            girl["skills"] = normalize_skill_map(skills_raw, MAIN_SKILLS)
 
             subskills_raw = girl.get("subskills") or {}
             if not isinstance(subskills_raw, dict):
                 subskills_raw = {}
-            girl["subskills"] = normalize_skill_map(subskills_raw)
+            girl["subskills"] = normalize_skill_map(subskills_raw, SUB_SKILLS)
 
             girl["prefs_skills"] = normalize_prefs(girl.get("prefs_skills", {}), MAIN_SKILLS)
             girl["prefs_subskills"] = normalize_prefs(girl.get("prefs_subskills", {}), SUB_SKILLS)
@@ -299,8 +299,8 @@ class GameService:
         image_url = base.get("image_url", "")
 
         base_level = int(base.get("base", {}).get("level", 1))
-        base_skills = normalize_skill_map(base.get("base", {}).get("skills", {}))
-        base_subskills = normalize_skill_map(base.get("base", {}).get("subskills", {}))
+        base_skills = normalize_skill_map(base.get("base", {}).get("skills", {}), MAIN_SKILLS)
+        base_subskills = normalize_skill_map(base.get("base", {}).get("subskills", {}), SUB_SKILLS)
 
         bio = base.get("bio", {}) or {}
         prefs = base.get("prefs", {}) or {}

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from src.game.repository import DataStore
 from src.game.services import GameService
+from src.models import MAIN_SKILLS, SUB_SKILLS
 
 
 class GachaRollTestCase(unittest.TestCase):
@@ -32,8 +33,16 @@ class GachaRollTestCase(unittest.TestCase):
                     "rarity": "R",
                     "base": {
                         "level": 1,
-                        "skills": {},
-                        "subskills": {},
+                        "skills": {
+                            "Human": {"level": 2, "exp": 15},
+                            "Monster": 1,
+                            "Forbidden": {"level": 9},
+                        },
+                        "subskills": {
+                            "VAGINAL": {"level": 1, "xp": 5},
+                            "ANAL": {"level": 0, "exp": 8},
+                            "Weird": 3,
+                        },
                     },
                 }
             ]
@@ -92,6 +101,20 @@ class GachaRollTestCase(unittest.TestCase):
         stored = self.service.load_player(uid)
         self.assertIsNotNone(stored)
         self.assertEqual(stored.currency, new_starter_coins)
+
+    def test_catalog_skills_are_normalized(self):
+        uid = 999
+        player = self.service.grant_starter_pack(uid)
+        self.assertIsNotNone(player)
+        self.assertEqual(len(player.girls), 1)
+
+        girl = player.girls[0]
+        self.assertEqual(set(girl.skills), set(MAIN_SKILLS))
+        self.assertEqual(set(girl.subskills), set(SUB_SKILLS))
+        self.assertEqual(girl.skills["Human"], {"level": 2, "xp": 15})
+        self.assertEqual(girl.skills["Monster"], {"level": 1, "xp": 0})
+        self.assertEqual(girl.subskills["ANAL"], {"level": 0, "xp": 8})
+        self.assertEqual(girl.subskills["VAGINAL"], {"level": 1, "xp": 5})
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,39 @@
 import unittest
 
-from src.models import BrothelState, Job, PROMOTE_COINS_PER_RENOWN, now_ts
+from src.models import (
+    BrothelState,
+    Job,
+    MAIN_SKILLS,
+    PROMOTE_COINS_PER_RENOWN,
+    SUB_SKILLS,
+    normalize_skill_map,
+    now_ts,
+)
+
+
+class SkillNormalizationTests(unittest.TestCase):
+    def test_normalize_skill_map_filters_unknown_keys(self):
+        raw_main = {
+            "Human": {"level": 2, "exp": 15},
+            "Monster": 1,
+            "Forbidden": {"level": 7},
+        }
+        normalized_main = normalize_skill_map(raw_main, MAIN_SKILLS)
+
+        self.assertEqual(set(normalized_main), set(MAIN_SKILLS))
+        self.assertEqual(normalized_main["Human"], {"level": 2, "xp": 15})
+        self.assertEqual(normalized_main["Monster"], {"level": 1, "xp": 0})
+
+        raw_sub = {
+            "VAGINAL": {"level": 1, "xp": 5},
+            "ANAL": {"level": 0, "exp": 3},
+            "Unknown": 4,
+        }
+        normalized_sub = normalize_skill_map(raw_sub, SUB_SKILLS)
+
+        self.assertEqual(set(normalized_sub), set(SUB_SKILLS))
+        self.assertEqual(normalized_sub["ANAL"], {"level": 0, "xp": 3})
+        self.assertNotIn("Unknown", normalized_sub)
 
 
 class BrothelPromotionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ensure skill normalization only keeps configured main and sub skill names
- update game service helpers to pass the appropriate skill lists during load and catalog conversions
- add tests covering filtered skill maps for direct helpers, gacha rewards, and player loading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe162f3ec8327b86d979bffbae15c