### PR TITLE
Исправление повторного применения относительного base_dir

### DIFF
--- a/src/game/repository.py
+++ b/src/game/repository.py
@@ -18,7 +18,9 @@ class DataStore:
             resolved_base = Path(base_dir).expanduser()
             if not resolved_base.is_absolute():
                 resolved_base = default_base / resolved_base
-        self.base_dir = resolved_base.resolve()
+        resolved_base = resolved_base.resolve()
+        self.base_dir = resolved_base
+        self._base_anchor = resolved_base
         self.data_dir = self.base_dir / "data"
         self.users_dir = self.data_dir / "users"
         self.market_dir = self.data_dir / "markets"
@@ -49,10 +51,10 @@ class DataStore:
             return
 
         base_override = paths.get("base_dir")
-        if base_override is not None:
-            self.base_dir = self._coerce_path(base_override, self.base_dir)
-
         base_dir = self.base_dir
+        if base_override is not None:
+            base_dir = self._coerce_path(base_override, self._base_anchor)
+            self.base_dir = base_dir
 
         data_dir_value = paths.get("data_dir")
         users_dir_value = paths.get("users_dir") or paths.get("users")

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -174,6 +174,10 @@ class ConfigOverridesTests(unittest.TestCase):
     def test_config_reload_survives_base_dir_override(self):
         override_root = self.base_path / "override_root"
         override_root.mkdir(parents=True, exist_ok=True)
+        expected_initial_base = self.base_path.resolve()
+        expected_override_base = override_root.resolve()
+
+        self.assertEqual(self.store.base_dir, expected_initial_base)
 
         _write_config(
             self.base_path,
@@ -190,6 +194,7 @@ class ConfigOverridesTests(unittest.TestCase):
 
         first_market = self.service.generate_market(uid=21, forced_level=1)
         self.assertEqual(len(first_market.jobs), 4)
+        self.assertEqual(self.store.base_dir, expected_override_base)
 
         time.sleep(0.01)
         _write_config(
@@ -207,6 +212,7 @@ class ConfigOverridesTests(unittest.TestCase):
 
         refreshed_market = self.service.generate_market(uid=22, forced_level=1)
         self.assertEqual(len(refreshed_market.jobs), 8)
+        self.assertEqual(self.store.base_dir, expected_override_base)
 
 
 class ResolveJobTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- зафиксировал исходный базовый каталог и использовал его как якорь для относительных переопределений
- расширил тест конфигурации, чтобы убедиться, что повторные относительные base_dir не углубляют путь

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbec1060ec83278a2353f48309ae41