### PR TITLE
Ensure girls command applies brothel decay

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -889,6 +889,8 @@ class Core(commands.Cog):
             return
 
         brothel = pl.ensure_brothel()
+        brothel.apply_decay()
+        pl.renown = brothel.renown
 
         pages: list[discord.Embed] = []
         files: list[str | None] = []
@@ -901,9 +903,9 @@ class Core(commands.Cog):
                 files.append(None)
             pages.append(embed)
 
-        save_player(pl)
         view = Paginator(pages, interaction.user.id, timeout=120, files=files)
         await view.send(interaction)
+        save_player(pl)
 
     @app_commands.command(name="top", description="Show leaderboards for brothels or girls")
     @app_commands.choices(

--- a/tests/test_core_commands.py
+++ b/tests/test_core_commands.py
@@ -352,7 +352,7 @@ def test_girls_lists_owned_girls(monkeypatch):
     core.bot = MagicMock()
 
     girl = SimpleNamespace()
-    brothel = SimpleNamespace()
+    brothel = SimpleNamespace(apply_decay=lambda: None, renown=42)
     player = SimpleNamespace(girls=[girl], ensure_brothel=lambda: brothel)
     monkeypatch.setattr("src.cogs.core.load_player", lambda uid: player)
     save_mock = MagicMock()


### PR DESCRIPTION
## Summary
- apply brothel decay and sync renown before rendering the girls list
- persist the player after sending the paginator response
- adjust the girls command test double to provide decay and renown attributes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc594bb9d48327b0e77952e27811e0