### PR TITLE
Apply brothel decay before healing

### DIFF
--- a/src/cogs/core.py
+++ b/src/cogs/core.py
@@ -1124,6 +1124,8 @@ class Core(commands.Cog):
             return
 
         brothel = pl.ensure_brothel()
+        brothel.apply_decay()
+        pl.renown = brothel.renown
         girl.normalize_skill_structs()
         girl.apply_regen(brothel)
 


### PR DESCRIPTION
## Summary
- call brothel.apply_decay in the /heal command and sync the player's renown to the brothel
- update heal command tests to model brothel decay and verify regen uses the refreshed state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc594bf420832786746c87ba82f249