### PR TITLE
Reset base directory when override removed

### DIFF
--- a/src/game/repository.py
+++ b/src/game/repository.py
@@ -51,10 +51,11 @@ class DataStore:
             return
 
         base_override = paths.get("base_dir")
-        base_dir = self.base_dir
         if base_override is not None:
             base_dir = self._coerce_path(base_override, self._base_anchor)
-            self.base_dir = base_dir
+        else:
+            base_dir = self._base_anchor
+        self.base_dir = base_dir
 
         data_dir_value = paths.get("data_dir")
         users_dir_value = paths.get("users_dir") or paths.get("users")
@@ -96,14 +97,14 @@ class DataStore:
         if catalog_value is not None:
             self.catalog_path = self._coerce_path(catalog_value, base_dir)
         else:
-            self.catalog_path = self.data_dir / "girls_catalog.json"
+            self.catalog_path = data_dir / "girls_catalog.json"
         self._catalog_cache = None
         self._catalog_mtime = None
 
         if assets_value is not None:
             self.assets_dir = self._coerce_path(assets_value, base_dir)
         else:
-            self.assets_dir = self.base_dir / "assets" / "girls"
+            self.assets_dir = base_dir / "assets" / "girls"
 
         self._ensure_dirs()
 

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -214,6 +214,59 @@ class ConfigOverridesTests(unittest.TestCase):
         self.assertEqual(len(refreshed_market.jobs), 8)
         self.assertEqual(self.store.base_dir, expected_override_base)
 
+    def test_base_dir_override_removed_resets_to_defaults(self):
+        override_root = self.base_path / "override_root"
+        override_root.mkdir(parents=True, exist_ok=True)
+        expected_override_base = override_root.resolve()
+        expected_default_base = self.base_path.resolve()
+
+        _write_config(
+            self.base_path,
+            {
+                "paths": {
+                    "base_dir": "override_root",
+                }
+            },
+        )
+
+        # Применяем оверрайд и убеждаемся, что все директории смещены.
+        self.service.config
+        self.assertEqual(self.store.base_dir, expected_override_base)
+        self.assertEqual(self.store.data_dir, expected_override_base / "data")
+        self.assertEqual(self.store.users_dir, expected_override_base / "data" / "users")
+        self.assertEqual(self.store.market_dir, expected_override_base / "data" / "markets")
+        self.assertEqual(
+            self.store.catalog_path,
+            expected_override_base / "data" / "girls_catalog.json",
+        )
+        self.assertEqual(
+            self.store.assets_dir,
+            expected_override_base / "assets" / "girls",
+        )
+
+        time.sleep(0.01)
+        _write_config(
+            self.base_path,
+            {
+                "paths": {},
+            },
+        )
+
+        # После удаления base_dir должны использоваться стандартные директории.
+        self.service.config
+        self.assertEqual(self.store.base_dir, expected_default_base)
+        self.assertEqual(self.store.data_dir, expected_default_base / "data")
+        self.assertEqual(self.store.users_dir, expected_default_base / "data" / "users")
+        self.assertEqual(self.store.market_dir, expected_default_base / "data" / "markets")
+        self.assertEqual(
+            self.store.catalog_path,
+            expected_default_base / "data" / "girls_catalog.json",
+        )
+        self.assertEqual(
+            self.store.assets_dir,
+            expected_default_base / "assets" / "girls",
+        )
+
 
 class ResolveJobTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- ensure the data store falls back to the original base directory when the configuration no longer specifies `paths.base_dir`
- rebuild derived paths from the refreshed base directory
- add a regression test confirming default directories are restored after removing the base override

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc59535df88327b614a4f9a9cc5d84